### PR TITLE
Mise a jour Mardi,Mercredi(2025): Mercredi, Jeudi(2026)

### DIFF
--- a/index.md
+++ b/index.md
@@ -20,8 +20,8 @@ layout: default
 Cette année, le PG Day France met le cap sur Toulouse, au siège de Météo France (42 avenue Gaspard Coriolis), les 3 et 4 juin 2026 !
 
 <strong>Au programme de ces deux jours :</strong>
-* <strong>Mardi 3 juin</strong> : Une journée entièrement dédiée aux ateliers (4 ateliers au choix).
-* <strong>Mercredi 4 juin</strong> : Une journée de conférences pour échanger avec la communauté et les experts.
+* <strong>Mercredi 3 juin</strong> : Une journée entièrement dédiée aux ateliers (4 ateliers au choix).
+* <strong>Jeudi 4 juin</strong> : Une journée de conférences pour échanger avec la communauté et les experts.
 
 Passionné·es, étudiant·es, DBA, développeur·euses et entreprises, tou·tes se retrouvent pour partager et apprendre autour de PostgreSQL !
 Restez connecté·es pour plus de détails et l'ouverture des inscriptions.

--- a/inscription.md
+++ b/inscription.md
@@ -57,5 +57,5 @@ title: Inscription
 </div>
 
 <hr/>
-<p><strong>Bon à savoir :</strong> en vous inscrivant à l'événement, vous aurez aussi accès à tous les ateliers du mardi 3 juin au matin. L'entrée aux ateliers est libre, <u>dans la limite des places disponibles</u>, mais elle est réservée aux personnes inscrites à l'événement.</p>
+<p><strong>Bon à savoir :</strong> en vous inscrivant à l'événement, vous aurez aussi accès à tous les ateliers du mercredi 3 juin au matin. L'entrée aux ateliers est libre, <u>dans la limite des places disponibles</u>, mais elle est réservée aux personnes inscrites à l'événement.</p>
 <p><strong>Good to know:</strong> By registering for the event, you'll also have access to all the workshops on Tuesday morning, June 3rd. Workshops are open on a first-come, first-served basis, <u>subject to availability</u>, and are only open to registered event participants.</p>

--- a/programme.md
+++ b/programme.md
@@ -5,7 +5,7 @@ layout: default
 
 # Programme / Schedule
 
-## Mardi 3 juin 2025 / Tuesday, June 3rd, 2025
+## Mercredi 3 juin 2025 / Wednesday, June 3rd, 2025
 
 <div class="schedule_bloc">
   <div class="schedule_time">09h30</div>
@@ -71,8 +71,8 @@ Nous nous concentrerons sur les métriques offertes par le système de statistiq
   </div>
   <div class="schedule_desc">
   <h3>Pause / Lunch break</h3>
-  <p>Le repas du mardi midi n'est pas inclus. Une pause est prévue pour se restaurer à l'extérieur. Merci de votre compréhension.</p>
-  <p>Tuesday lunch is not included. A break is scheduled so participants can eat outside. Thank you for your understanding.</p>
+  <p>Le repas du mercredi midi n'est pas inclus. Une pause est prévue pour se restaurer à l'extérieur. Merci de votre compréhension.</p>
+  <p>Wednesday lunch is not included. A break is scheduled so participants can eat outside. Thank you for your understanding.</p>
   </div>
 </div>
 
@@ -198,7 +198,7 @@ Nous nous concentrerons sur les métriques offertes par le système de statistiq
 </div>
 
 
-## Mercredi 4 juin 2025 / Wednesday, June 4th, 2025
+## Jeudi 4 juin 2025 / Thursday, June 4th, 2025
 
 <div class="schedule_bloc">
   <div class="schedule_time">08h30</div>


### PR DESCRIPTION
Xavier, sur Slack:

"Hello.
Alain Lesage vient de me faire remarquer que sur le site on parle du mardi 3 et mercredi 4 pour le prochain pgday.
Ce sont les jours de 2025. En 2026, les 3 et 4 tombent un mercredi et un jeudi."

Corrigé, à de multiples endroits. Merci à Xavier et Alain!
